### PR TITLE
IFS-3651: Correct Links Percentage badge for Link Checker

### DIFF
--- a/.github/workflows/link_checker.yml
+++ b/.github/workflows/link_checker.yml
@@ -69,17 +69,36 @@ jobs:
           successful=$(grep '✅ Successful' "$report_file" | awk -F'|' '{print $3}' | xargs)
           excluded=$(grep '👻 Excluded' "$report_file" | awk -F'|' '{print $3}' | xargs)
           
-          # Calculate the total incorrect links (errors + timeouts)
+          # Calculate the total correct, incorrect links (errors + timeouts)
           correct=$((successful + excluded))
+          incorrect=$((total - correct))
           
           # Calculate the percentage of correct links
           if [ "$total" -gt 0 ]; then
-            percentage=$(echo "scale=0; $correct * 100 / $total" | bc)
+            percentage=$(echo "scale=2; $correct * 100 / $total" | bc)
           else
             percentage=100
           fi
           
-          echo "Percentage of correct links: $percentage%"
+          echo "Links: $percentage% correct (Correct: $correct, Incorrect: $incorrect)"
           
-          # Save the percentage to the environment
+          # Save the percentage and totals to the environment
           echo "CORRECT_LINKS_PERCENTAGE=$percentage" >> $GITHUB_ENV
+          echo "CORRECT=$correct" >> $GITHUB_ENV
+          echo "INCORRECT=$incorrect" >> $GITHUB_ENV
+
+      - name: Update dynamic badge for correct links percentage
+        if: ${{ env.GIST_AUTH != '' && env.GIST_ID != '' }}
+        env:
+          GIST_AUTH: ${{ secrets.GIST_AUTH }}
+          GIST_ID: ${{ vars.GIST_ID }}
+        uses: schneegans/dynamic-badges-action@v1.7.0
+        with:
+          auth: ${{ env.GIST_AUTH }}
+          gistID: ${{ env.GIST_ID }}
+          filename: link_check_percentage.json
+          label: "Links"
+          message: "${{ env.CORRECT_LINKS_PERCENTAGE }}% correct (Correct: ${{ env.CORRECT }}, Incorrect: ${{ env.INCORRECT }})"
+          valColorRange: ${{ env.CORRECT_LINKS_PERCENTAGE }}
+          minColorRange: 0
+          maxColorRange: 100

--- a/.github/workflows/link_checker.yml
+++ b/.github/workflows/link_checker.yml
@@ -1,6 +1,9 @@
 name: Link Checker
 
 on:
+  push:
+    branches:
+      - feature/IFS-3651_web_link_checker_stats
   workflow_run:
     workflows: [Build Documentation]
     types: [completed]
@@ -15,7 +18,17 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Set up cache for docs artifact
+        id: cache-docs
+        uses: actions/cache@v4
+        with:
+          path: docs
+          key: ${{ runner.os }}-docs-${{ hashFiles('docs/**/*.html') }}
+          restore-keys: |
+            ${{ runner.os }}-docs-
+
       - name: Download docs artifact from the last successful workflow
+        if: steps.cache-docs.outputs.cache-hit != 'true'
         uses: dawidd6/action-download-artifact@v6
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -23,7 +36,7 @@ jobs:
           name: docs
           path: docs
           workflow_conclusion: success
-          branch: main
+          branch: feature/IFS-3651_web_link_checker_stats
 
       - name: Restore Lychee cache
         uses: actions/cache@v4
@@ -42,6 +55,12 @@ jobs:
             './docs/**/*.html'
           format: markdown
           output: link_checker_report.md
-          fail: true
+          fail: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload link checker report
+        uses: actions/upload-artifact@v4
+        with:
+          path: link_checker_report.md
+          name: link_checker_report

--- a/.github/workflows/link_checker.yml
+++ b/.github/workflows/link_checker.yml
@@ -59,8 +59,27 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Upload link checker report
-        uses: actions/upload-artifact@v4
-        with:
-          path: link_checker_report.md
-          name: link_checker_report
+      - name: Calculate correct links percentage
+        id: calculate_percentage
+        run: |
+          # Extract values from the link checker report                    
+          report_file="link_checker_report.md"
+
+          total=$(grep '🔍 Total' "$report_file" | awk -F'|' '{print $3}' | xargs)
+          successful=$(grep '✅ Successful' "$report_file" | awk -F'|' '{print $3}' | xargs)
+          excluded=$(grep '👻 Excluded' "$report_file" | awk -F'|' '{print $3}' | xargs)
+          
+          # Calculate the total incorrect links (errors + timeouts)
+          correct=$((successful + excluded))
+          
+          # Calculate the percentage of correct links
+          if [ "$total" -gt 0 ]; then
+            percentage=$(echo "scale=0; $correct * 100 / $total" | bc)
+          else
+            percentage=100
+          fi
+          
+          echo "Percentage of correct links: $percentage%"
+          
+          # Save the percentage to the environment
+          echo "CORRECT_LINKS_PERCENTAGE=$percentage" >> $GITHUB_ENV

--- a/.github/workflows/link_checker.yml
+++ b/.github/workflows/link_checker.yml
@@ -1,9 +1,6 @@
 name: Link Checker
 
 on:
-  push:
-    branches:
-      - feature/IFS-3651_web_link_checker_stats
   workflow_run:
     workflows: [Build Documentation]
     types: [completed]
@@ -18,15 +15,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up cache for docs artifact
-        id: cache-docs
-        uses: actions/cache@v4
-        with:
-          path: docs
-          key: ${{ runner.os }}-docs-${{ hashFiles('docs/**/*.html') }}
-          restore-keys: |
-            ${{ runner.os }}-docs-
-
       - name: Download docs artifact from the last successful workflow
         if: steps.cache-docs.outputs.cache-hit != 'true'
         uses: dawidd6/action-download-artifact@v6
@@ -36,7 +24,7 @@ jobs:
           name: docs
           path: docs
           workflow_conclusion: success
-          branch: feature/IFS-3651_web_link_checker_stats
+          branch: main
 
       - name: Restore Lychee cache
         uses: actions/cache@v4
@@ -97,7 +85,7 @@ jobs:
           auth: ${{ env.GIST_AUTH }}
           gistID: ${{ env.GIST_ID }}
           filename: link_check_percentage.json
-          label: "Links"
+          label: "🔗 Links"
           message: "${{ env.CORRECT_LINKS_PERCENTAGE }}% correct (Correct: ${{ env.CORRECT }}, Incorrect: ${{ env.INCORRECT }})"
           valColorRange: ${{ env.CORRECT_LINKS_PERCENTAGE }}
           minColorRange: 0

--- a/.github/workflows/link_checker.yml
+++ b/.github/workflows/link_checker.yml
@@ -1,11 +1,10 @@
 name: Link Checker
 
 on:
-  push:
-    branches:
-      - main
-  schedule:
-    - cron: '0 1 * * 0' # every Sunday at 01:00
+  workflow_run:
+    workflows: [Build Documentation]
+    types: [completed]
+    branches: [main]
   workflow_dispatch:
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -54,3 +54,55 @@ content:
 If you are behind a company firewall, you may need to set additional root CAs to make secure connections work.
 
 Setting additional root CAs can be done [by setting the environment variable `NODE_EXTRA_CA_CERTS`](https://nodejs.org/api/cli.html#node_extra_ca_certsfile), e.g. in your IDE.
+
+## Setting Up the Dynamic Badge for Link Checker
+
+The Link Checker workflow now calculates the percentage of correct links and generates a dynamic badge. This badge shows the percentage of correct links along with the number of correct and incorrect links.
+
+### Configuring the Badge with Gist
+
+To enable the dynamic badge, follow these steps:
+
+1. **Create a Gist:**
+    - Go to [gist.github.com](https://gist.github.com/).
+    - Create a new Gist named `link_check_percentage.json` (the name and content can be anything initially).
+    - Note the Gist ID, which is the long alphanumeric part of the Gist URL.
+
+2. **Set Up Repository Variables and Secrets:**
+    - **GIST_ID (Repository Variable):**  
+      Add the Gist ID (e.g., `8f6459c2417de7534f64d98360dde866`) as a variable named `GIST_ID` in the repository settings.
+
+    - **GIST_AUTH (Repository Secret):**  
+      Create a personal access token with the `gist` scope. Add this token as a secret in the repository settings with the name `GIST_AUTH`.
+
+3. **Usage in Workflow:**
+    - The workflow uses these variables to update the dynamic badge with the percentage of correct links:
+      ```yaml
+      - name: Update dynamic badge for correct links percentage
+        if: ${{ env.GIST_AUTH != '' && env.GIST_ID != '' }}
+        env:
+          GIST_AUTH: ${{ secrets.GIST_AUTH }}
+          GIST_ID: ${{ vars.GIST_ID }}
+        uses: schneegans/dynamic-badges-action@v1.7.0
+        with:
+          auth: ${{ env.GIST_AUTH }}
+          gistID: ${{ env.GIST_ID }}
+          filename: link_check_percentage.json
+          label: "🔗 Links"
+          message: "${{ env.CORRECT_LINKS_PERCENTAGE }}% correct (Correct: ${{ env.CORRECT }}, Incorrect: ${{ env.INCORRECT }})"
+          valColorRange: ${{ env.CORRECT_LINKS_PERCENTAGE }}
+          minColorRange: 0
+          maxColorRange: 100
+      ```
+
+4. **Add the Badge to README:**
+    - Include the badge in your `README.md`:
+      ```markdown
+      [![Links](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/<your-username>/<gist-ID>/raw/link_check_percentage.json)](https://github.com/IsyFact/isyfact.github.io/actions/workflows/link_checker.yml)
+      ```
+    - For example:
+      ```markdown
+      [![Links](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/huy-tran-msg/cd34647bc4a492cb10e296417a0c612c/raw/link_check_percentage.json)](https://github.com/IsyFact/isyfact.github.io/actions/workflows/link_checker.yml)
+      ```
+      
+This setup will display a real-time percentage of correct links in your README, keeping the health of your documentation links visible.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 [![Check Links](https://github.com/IsyFact/isyfact.github.io/actions/workflows/link_checker.yml/badge.svg)](https://github.com/IsyFact/isyfact.github.io/actions/workflows/link_checker.yml)
 
+![badge](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/huy-tran-msg/cd34647bc4a492cb10e296417a0c612c/raw/link_check_percentage.json)
+
 # IsyFact Online Docs
 
 ## Publishing

--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
-[![Check Links](https://github.com/IsyFact/isyfact.github.io/actions/workflows/link_checker.yml/badge.svg)](https://github.com/IsyFact/isyfact.github.io/actions/workflows/link_checker.yml)
-
-![badge](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/huy-tran-msg/cd34647bc4a492cb10e296417a0c612c/raw/link_check_percentage.json)
+[![Links](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/huy-tran-msg/cd34647bc4a492cb10e296417a0c612c/raw/link_check_percentage.json)](https://github.com/IsyFact/isyfact.github.io/actions/workflows/link_checker.yml)
 
 # IsyFact Online Docs
 


### PR DESCRIPTION
# Description
- **Updated Workflow Trigger**:
  - The Link Checker workflow has been updated to run automatically after the Build Documentation workflow completes. This ensures that the link checker only runs after the documentation is fully built and the `docs` artifact exists, improving the reliability of the checks.

- **New Percentage Calculation and Badge Update**:
  - Added a step to calculate the percentage of correct links, including both successful and excluded links, and generate a dynamic badge. The badge displays the percentage of correct links along with the number of correct and incorrect links.
  - Needs to be configured with Gist for it to work, otherwise the step is skipped. [Guide](https://github.com/Schneegans/dynamic-badges-action?tab=readme-ov-file#%EF%B8%8F-configuration). In our case:
    - A Gist should be created with the name `link_check_percentage.json` (any name or content works)
    - `GIST_ID` variable in Repo Settings:  The ID of the created Gist. Something like `8f6459c2417de7534f64d98360dde866`.
    - `GIST_AUTH` secret in Repo Settings: Token with Gist scope

- **README Badge Update**:
  - The badge in the README.md file has been updated to reflect the dynamically generated badge showing the percentage of correct links. The badge is now linked to the Link Checker workflow.
  - Example (color range will work when the badge is correctly configured):
    <img width="324" alt="image" src="https://github.com/user-attachments/assets/226ebb06-1b7d-42ce-a5dd-5b3fae1a8f12">
