### PR TITLE
Feature/ifs 4421 entfernen baustein aus playbook für antora builds

### DIFF
--- a/.github/workflows/antora_build.yml
+++ b/.github/workflows/antora_build.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - feature/**
   schedule:
     - cron: '0 0 * * 0' # every Sunday at 00:00
   workflow_dispatch:

--- a/.github/workflows/antora_build.yml
+++ b/.github/workflows/antora_build.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - feature/**
   schedule:
     - cron: '0 0 * * 0' # every Sunday at 00:00
   workflow_dispatch:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 It focuses on changes to the UI, extensions and site-wide configuration options in the playbook.
 
 ## 2024
+- [2024-12-05] [UI] `IFS-4421`: removed entries for several separated modules
 - [2024-10-13] [UI] `IFS-4177`: added entries for new separated modules
 - [2024-10-07] [UI] `IFS-4006`: adjust build and playbook for IF 3.2.0 release
 - [2024-08-13] [UI] `IFS-3938`: adjust build and playbook for IF 3.1.0 release

--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -35,22 +35,7 @@ content:
     - url: ./isy-datetime
       branches: HEAD
       start_path: docs
-    - url: ./isy-datetime-persistence
-      branches: HEAD
-      start_path: docs
-    - url: ./isy-polling
-      branches: HEAD
-      start_path: docs
-    - url: ./isy-security
-      branches: HEAD
-      start_path: docs
     - url: ./isy-sonderzeichen
-      branches: HEAD
-      start_path: docs
-    - url: ./isy-task
-      branches: HEAD
-      start_path: docs
-    - url: ./isy-util
       branches: HEAD
       start_path: docs
     - url: ../isyfact.github.io


### PR DESCRIPTION
Alle neuen Bausteine bis auf datetime und sonderzeichen aus Playbook entfernt. Ergebnis ist bereits live:
https://isyfact.github.io/isyfact-standards-doku/dev/einstieg/einstieg.html