### PR TITLE
chore: IFS-4527 prevent build errors from tags

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -34,10 +34,9 @@ content:
       version:
         'doku/(*)': $1
     - url: ./isyfact-standards-3.3.0
-      tags: 3.3.0
+      branches: HEAD
       start_path: isyfact-standards-doc/src/docs/antora
-      version:
-        '(*)': $1
+      version: 3.3.0
     - url: ./isyfact-standards-3.2.2
       branches: doku/3.2.2
       start_path: isyfact-standards-doc/src/docs/antora


### PR DESCRIPTION
Explanation: If I remember correctly, Antora doesn't use the worktree if the tag is configured, which results in the LFS pointers not being resolved. The following workaround should help. Unfortunately, we can only test this in production.